### PR TITLE
None of your boost are belong to us

### DIFF
--- a/src/abstract_dynamic.hpp
+++ b/src/abstract_dynamic.hpp
@@ -1,7 +1,8 @@
+//boost free
 #ifndef ABSTRACT_DYNAMIC_HPP
 #define ABSTRACT_DYNAMIC_HPP
 
-#include <boost/cstdint.hpp>
+// #include <boost/cstdint.hpp>
 #include <cstdint>
 
 #include <string>
@@ -9,12 +10,15 @@
 class AbstractDynamicEntry
 {
 public:
-    AbstractDynamicEntry(boost::uint64_t p_tag, boost::uint64_t p_value);
+    // AbstractDynamicEntry(boost::uint64_t p_tag, boost::uint64_t p_value);
+    AbstractDynamicEntry(std::uint64_t p_tag, std::uint64_t p_value);
     AbstractDynamicEntry(const AbstractDynamicEntry& p_rhs);
     ~AbstractDynamicEntry();
 
-    boost::uint64_t getTag() const;
-    boost::uint64_t getValue() const;
+    // boost::uint64_t getTag() const;
+    // boost::uint64_t getValue() const;
+    std::uint64_t getTag() const;
+    std::uint64_t getValue() const;
 
     bool hasString() const;
     void setString(const std::string& p_value);
@@ -29,8 +33,10 @@ private:
     AbstractDynamicEntry& operator=(const AbstractDynamicEntry& p_rhs);
 
 private:
-    boost::uint64_t m_tag;
-    boost::uint64_t m_value;
+    // boost::uint64_t m_tag;
+    // boost::uint64_t m_value;
+    std::uint64_t m_tag;
+    std::uint64_t m_value;
     std::string m_stringValue;
 };
 

--- a/src/abstract_elfheader.hpp
+++ b/src/abstract_elfheader.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef ABSTRACT_ELFHEADER_HPP
 #define ABSTRACT_ELFHEADER_HPP
 
@@ -6,7 +7,7 @@
 #include <vector>
 #include <string>
 #include <cstddef>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 namespace elf
@@ -75,31 +76,40 @@ public:
     std::string getVersion() const;
 
     //! \return the virtual address of the entry pointer
-    boost::uint64_t getEntryPoint() const;
+    // boost::uint64_t getEntryPoint() const;
+    std::uint64_t getEntryPoint() const;
 
     //! \return the offset to the program header
-    boost::uint32_t getProgramOffset() const;
+    // boost::uint32_t getProgramOffset() const;
+    std::uint32_t getProgramOffset() const;
 
     //! \return the number of expected program header entries
-    boost::uint16_t getProgramCount() const;
+    // boost::uint16_t getProgramCount() const;
+    std::uint16_t getProgramCount() const;
 
     //! \return the size of a program header entry
-    boost::uint16_t getProgramSize() const;
+    // boost::uint16_t getProgramSize() const;
+    std::uint16_t getProgramSize() const;
 
     //! \return the offset to the section header
-    boost::uint32_t getSectionOffset() const;
+    // boost::uint32_t getSectionOffset() const;
+    std::uint32_t getSectionOffset() const;
 
     //! \return the size of a section table entry
-    boost::uint16_t getSectionSize() const;
+    // boost::uint16_t getSectionSize() const;
+    std::uint16_t getSectionSize() const;
 
     //! \return the number of entries in the section header
-    boost::uint16_t getSectionCount() const;
+    // boost::uint16_t getSectionCount() const;
+    std::uint16_t getSectionCount() const;
 
     //! \return the index of the section header string table
-    boost::uint16_t getStringTableIndex() const;
+    // boost::uint16_t getStringTableIndex() const;
+    std::uint16_t getStringTableIndex() const;
 
     //! \return the offset of the section header string table
-    boost::uint32_t getStringTableOffset(const char* p_start) const;
+    // boost::uint32_t getStringTableOffset(const char* p_start) const;
+    std::uint32_t getStringTableOffset(const char* p_start) const;
 
     //! \return an if there is le or not
     bool isLE() const;
@@ -116,7 +126,9 @@ public:
      * \param[in,out] p_reasons the reasons for scoring vector
      * \param[in,out] p_capabilities the capabilities map
      */
-    void evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+    // void evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+    //               std::map<elf::Capabilties, std::set<std::string> >& p_capabilities) const;
+    void evaluate(std::vector<std::pair<std::int32_t, std::string> >& p_reasons,
                   std::map<elf::Capabilties, std::set<std::string> >& p_capabilities) const;
 
 private:
@@ -131,7 +143,8 @@ private:
     bool m_is64;
 
     //! Stores the file size due to true.asm silliness
-    boost::uint32_t m_fileSize;
+    // boost::uint32_t m_fileSize;
+    std::uint32_t m_fileSize;
 
     //! A pointer to the 32 bit version of the ELF header
     const elf::elf_header_32* m_header32;

--- a/src/abstract_programheader.hpp
+++ b/src/abstract_programheader.hpp
@@ -1,9 +1,10 @@
+//boost free
 #ifndef ABSTRACT_PROGRAM_HEADER_HPP
 #define ABSTRACT_PROGRAM_HEADER_HPP
 
 #include <vector>
 #include <string>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 namespace elf
@@ -30,7 +31,8 @@ public:
      * \param[in] p_is64 indicates if the binary is 64 bit or 32 bit
      * \param[in] p_isLE indicates if the binary is little endian
      */
-    AbstractProgramHeader(const char* p_data, boost::uint16_t p_size,
+    // AbstractProgramHeader(const char* p_data, boost::uint16_t p_size,
+    AbstractProgramHeader(const char* p_data, std::uint16_t p_size,
                           bool p_is64, bool p_isLE);
     AbstractProgramHeader(const AbstractProgramHeader& p_rhs);
 
@@ -43,15 +45,24 @@ public:
     bool isWritable() const;
     std::string getFlagsString() const;
     std::string getName() const;
-    boost::uint32_t getType() const;
-    boost::uint64_t getOffset() const;
-    boost::uint64_t getVirtualAddress() const;
+    // boost::uint32_t getType() const;
+    // boost::uint64_t getOffset() const;
+    // boost::uint64_t getVirtualAddress() const;
+    // std::string getVirtualAddressString() const;
+    // boost::uint64_t getPhysicalAddress() const;
+    // std::string getPhysicalAddressString() const;
+    // boost::uint64_t getFileSize() const;
+    // boost::uint64_t getMemorySize() const;
+    // boost::uint32_t getFlags() const;
+    std::uint32_t getType() const;
+    std::uint64_t getOffset() const;
+    std::uint64_t getVirtualAddress() const;
     std::string getVirtualAddressString() const;
-    boost::uint64_t getPhysicalAddress() const;
+    std::uint64_t getPhysicalAddress() const;
     std::string getPhysicalAddressString() const;
-    boost::uint64_t getFileSize() const;
-    boost::uint64_t getMemorySize() const;
-    boost::uint32_t getFlags() const;
+    std::uint64_t getFileSize() const;
+    std::uint64_t getMemorySize() const;
+    std::uint32_t getFlags() const;
 
 private:
 

--- a/src/abstract_sectionheader.hpp
+++ b/src/abstract_sectionheader.hpp
@@ -1,9 +1,10 @@
+//boost free
 #ifndef ABSTRACT_SECTION_HEADER_HPP
 #define ABSTRACT_SECTION_HEADER_HPP
 
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 #ifdef UNIT_TESTS
@@ -23,9 +24,12 @@ class AbstractSectionHeader
 {
 public:
 
-    AbstractSectionHeader(const char* p_data, boost::uint16_t p_size,
-                          const char* p_file, boost::uint64_t p_fileSize,
-                          boost::uint8_t p_strIndex,
+    // AbstractSectionHeader(const char* p_data, boost::uint16_t p_size,
+    //                       const char* p_file, boost::uint64_t p_fileSize,
+    //                       boost::uint8_t p_strIndex,
+    AbstractSectionHeader(const char* p_data, std::uint16_t p_size,
+                          const char* p_file, std::uint64_t p_fileSize,
+                          std::uint8_t p_strIndex,
                           const std::vector<AbstractSectionHeader>& p_sections,
                           bool p_is64, bool p_isLE);
     AbstractSectionHeader(const AbstractSectionHeader& p_rhs);
@@ -40,16 +44,26 @@ public:
     std::string getName() const;
     std::string getTypeString() const;
     std::string getFlagsString() const;
-    boost::uint32_t getType() const;
-    boost::uint64_t getFlags() const;
-    boost::uint64_t getVirtAddress() const;
+    // boost::uint32_t getType() const;
+    // boost::uint64_t getFlags() const;
+    // boost::uint64_t getVirtAddress() const;
+    // std::string getVirtAddressString() const;
+    // boost::uint64_t getPhysOffset() const;
+    // boost::uint64_t getSize() const;
+    // boost::uint32_t getLink() const;
+    // boost::uint32_t getInfo() const;
+    // boost::uint64_t getAddrAlign() const;
+    // boost::uint64_t getEntSize() const;
+    std::uint32_t getType() const;
+    std::uint64_t getFlags() const;
+    std::uint64_t getVirtAddress() const;
     std::string getVirtAddressString() const;
-    boost::uint64_t getPhysOffset() const;
-    boost::uint64_t getSize() const;
-    boost::uint32_t getLink() const;
-    boost::uint32_t getInfo() const;
-    boost::uint64_t getAddrAlign() const;
-    boost::uint64_t getEntSize() const;
+    std::uint64_t getPhysOffset() const;
+    std::uint64_t getSize() const;
+    std::uint32_t getLink() const;
+    std::uint32_t getInfo() const;
+    std::uint64_t getAddrAlign() const;
+    std::uint64_t getEntSize() const;
 
 private:
     AbstractSectionHeader& operator=(const AbstractSectionHeader& p_rhs);
@@ -76,10 +90,12 @@ private:
     const char* m_fileStart;
 
     //! The size of the file in memory
-    boost::uint64_t m_size;
+    // boost::uint64_t m_size;
+    std::uint64_t m_size;
 
     //! Index of the string table
-    boost::uint8_t m_strIndex;
+    // boost::uint8_t m_strIndex;
+    std::uint8_t m_strIndex;
 
     //! Indicates if the binary is 64 bit or not
     bool m_is64;

--- a/src/abstract_segments.cpp
+++ b/src/abstract_segments.cpp
@@ -437,7 +437,8 @@ std::string AbstractSegments::determineFamily() const
     return "Undetermined";
 }
 
-std::string AbstractSegments::printSegment(boost::uint64_t p_offset) const
+// std::string AbstractSegments::printSegment(boost::uint64_t p_offset) const
+std::string AbstractSegments::printSegment(std::uint64_t p_offset) const
 {
     // BOOST_FOREACH(const SegmentType& segment, m_types)
     for(const auto& segment : m_types)

--- a/src/datastructures/search_node.cpp
+++ b/src/datastructures/search_node.cpp
@@ -1,3 +1,4 @@
+//boost free
 #include "search_node.hpp"
 
 #include <cstddef>

--- a/src/datastructures/search_node.hpp
+++ b/src/datastructures/search_node.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef ELFPARSER_SEARCHNODE_HPP
 #define ELFPARSER_SEARCHNODE_HPP
 

--- a/src/datastructures/search_tree.cpp
+++ b/src/datastructures/search_tree.cpp
@@ -1,6 +1,8 @@
+//boost free
 #include "search_tree.hpp"
-#include <boost/concept_check.hpp>
+//#include <boost/concept_check.hpp>
 #include <concepts>
+#include <cassert>
 
 SearchTree::SearchTree() :
     m_rootNode(),
@@ -11,7 +13,8 @@ SearchTree::SearchTree() :
 
 SearchTree::~SearchTree()
 {
-    m_nodeVector.release();
+    // m_nodeVector.release();
+    m_nodeVector.clear();
 }
 
 void SearchTree::addWord(const std::string& p_string, void* p_storeData)
@@ -118,8 +121,10 @@ void SearchTree::doAddWord(SearchNode* p_node, const unsigned char* p_input,
     {
         /* create a node to transition to - store the allocated node in a vector
          * for easy clean up */
-        m_nodeVector.push_back(new SearchNode());
-        SearchNode* newNode = &m_nodeVector.back();
+        // m_nodeVector.push_back(new SearchNode());
+        m_nodeVector.push_back(std::make_unique<SearchNode>());
+        // SearchNode* newNode = &m_nodeVector.back();
+        SearchNode* newNode = m_nodeVector.back().get();
 
         p_node->setNext(p_input[0], newNode);
         p_node = newNode;

--- a/src/datastructures/search_tree.hpp
+++ b/src/datastructures/search_tree.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef ELFPARSER_SEARCH_HPP
 #define ELFPARSER_SEARCH_HPP
 
@@ -7,8 +8,9 @@
 #include <queue>
 #include <string>
 
-#include <boost/ptr_container/ptr_vector.hpp>
+//#include <boost/ptr_container/ptr_vector.hpp>
 #include <vector>
+#include <memory>
 
 /*
  *  This is a basic automata implemenation. Used for efficient searching.
@@ -47,7 +49,8 @@ private:
 
     bool m_ready;
 
-    boost::ptr_vector<SearchNode> m_nodeVector;
+    // boost::ptr_vector<SearchNode> m_nodeVector;
+    std::vector<std::unique_ptr<SearchNode>> m_nodeVector;
 };
 
 #endif

--- a/src/datastructures/search_value.hpp
+++ b/src/datastructures/search_value.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef SEARCH_VALUE_HPP
 #define SEARCH_VALUE_HPP
 

--- a/src/dynamicsection.hpp
+++ b/src/dynamicsection.hpp
@@ -29,7 +29,8 @@ public:
     DynamicSection();
     ~DynamicSection();
 
-    void createDynamic(const char* p_start, boost::uint32_t p_offset,
+    // void createDynamic(const char* p_start, boost::uint32_t p_offset,
+    void createDynamic(const char* p_start, std::uint32_t p_offset,
                     //    boost::uint32_t p_size, boost::uint64_t p_baseAddress,
                        std::uint32_t p_size, std::uint64_t p_baseAddress,
                        bool p_is64, bool p_isLE, const AbstractSegments& p_segments);

--- a/src/segment_types/comment_segment.cpp
+++ b/src/segment_types/comment_segment.cpp
@@ -1,9 +1,12 @@
+//boost free
 #include "comment_segment.hpp"
 
 #include <sstream>
 
-CommentSegment::CommentSegment(const char* start, boost::uint32_t p_offset,
-                               boost::uint32_t p_size,
+// CommentSegment::CommentSegment(const char* start, boost::uint32_t p_offset,
+//                                boost::uint32_t p_size,
+CommentSegment::CommentSegment(const char* start, std::uint32_t p_offset,
+                               std::uint32_t p_size,
                                elf::section_type p_type) :
                                SegmentType(start, p_offset, p_size, p_type),
     m_comment(start + p_offset)

--- a/src/segment_types/comment_segment.hpp
+++ b/src/segment_types/comment_segment.hpp
@@ -1,10 +1,11 @@
+//boost free
 #ifndef COMMENT_SEGMENT_HPP
 #define COMMENT_SEGMENT_HPP
 
 #include "segment_type.hpp"
 
 #include <string>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 /*!
@@ -23,8 +24,10 @@ public:
      * \param[in] p_size the size of this segment
      * \param[in] p_type elf::k_progbits
      */
-    CommentSegment(const char* p_start, boost::uint32_t p_offset,
-                   boost::uint32_t p_size, elf::section_type p_type);
+    // CommentSegment(const char* p_start, boost::uint32_t p_offset,
+    //                boost::uint32_t p_size, elf::section_type p_type);
+        CommentSegment(const char* p_start, std::uint32_t p_offset,
+                   std::uint32_t p_size, elf::section_type p_type);
 
     //! Nothing of note
     ~CommentSegment();

--- a/src/segment_types/debuglink_segment.cpp
+++ b/src/segment_types/debuglink_segment.cpp
@@ -1,9 +1,12 @@
+//boost free
 #include "debuglink_segment.hpp"
 
 #include <sstream>
 
-DebugLinkSegment::DebugLinkSegment(const char* start, boost::uint32_t p_offset,
-                                   boost::uint32_t p_size,
+// DebugLinkSegment::DebugLinkSegment(const char* start, boost::uint32_t p_offset,
+//                                    boost::uint32_t p_size,
+DebugLinkSegment::DebugLinkSegment(const char* start, std::uint32_t p_offset,
+                                   std::uint32_t p_size,
                                    elf::section_type p_type) :
     SegmentType(start, p_offset, p_size, p_type),
     m_file(start + p_offset)

--- a/src/segment_types/debuglink_segment.hpp
+++ b/src/segment_types/debuglink_segment.hpp
@@ -1,10 +1,11 @@
+//boost free
 #ifndef DEBUGLINK_SEGMENT_HPP
 #define DEBUGLINK_SEGMENT_HPP
 
 #include "segment_type.hpp"
 
 #include <string>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 /*!
@@ -22,8 +23,10 @@ public:
      * \param[in] p_size the size of this segment
      * \param[in] p_type elf::k_progbits
      */
-    DebugLinkSegment(const char* start, boost::uint32_t p_offset,
-                     boost::uint32_t p_size, elf::section_type p_type);
+    // DebugLinkSegment(const char* start, boost::uint32_t p_offset,
+    //                  boost::uint32_t p_size, elf::section_type p_type);
+    DebugLinkSegment(const char* start, std::uint32_t p_offset,
+                     std::uint32_t p_size, elf::section_type p_type);
 
     //! Nothing of note
     ~DebugLinkSegment();

--- a/src/segment_types/interp_segment.cpp
+++ b/src/segment_types/interp_segment.cpp
@@ -1,9 +1,12 @@
+//boost free
 #include "interp_segment.hpp"
 
 #include <sstream>
 
-InterpSegment::InterpSegment(const char* start, boost::uint32_t p_offset,
-                             boost::uint32_t p_size,
+// InterpSegment::InterpSegment(const char* start, boost::uint32_t p_offset,
+//                              boost::uint32_t p_size,
+InterpSegment::InterpSegment(const char* start, std::uint32_t p_offset,
+                             std::uint32_t p_size,
                              elf::section_type p_type) :
     SegmentType(start, p_offset, p_size, p_type),
     m_interpreter(start + p_offset)

--- a/src/segment_types/interp_segment.hpp
+++ b/src/segment_types/interp_segment.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef INTERP_SEGMENT_HPP
 #define INTERP_SEGMENT_HPP
 
@@ -5,7 +6,7 @@
 
 #include <string>
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 /*!
@@ -23,8 +24,10 @@ public:
      * \param[in] p_size the size of this segment
      * \param[in] p_type elf::k_progbits
      */
-    InterpSegment(const char* start, boost::uint32_t p_offset,
-                  boost::uint32_t p_size, elf::section_type p_type);
+    // InterpSegment(const char* start, boost::uint32_t p_offset,
+    //               boost::uint32_t p_size, elf::section_type p_type);
+    InterpSegment(const char* start, std::uint32_t p_offset,
+                  std::uint32_t p_size, elf::section_type p_type);
 
     //! Nothing of note
     ~InterpSegment();

--- a/src/segment_types/note_segment.cpp
+++ b/src/segment_types/note_segment.cpp
@@ -1,3 +1,4 @@
+//boost free
 #include "note_segment.hpp"
 #include "../structures/noteformat.hpp"
 
@@ -5,29 +6,47 @@
 #include <sstream>
 #include <iostream>
 
-#include <boost/assign.hpp>
+//#include <boost/assign.hpp>
 #include <map>
 
-#include <boost/lexical_cast.hpp>
+//#include <boost/lexical_cast.hpp>
 #include <sstream>
+#include <cstdint>
+#include <string>
 
 namespace
 {
-    const std::map<boost::uint32_t, std::string> type_map = boost::assign::map_list_of
-        ( 1, "NT_GNU_ABI_TAG")
-        ( 2, "NT_GNU_HWCAP")
-        ( 3, "NT_GNU_BUILD_ID")
-        ( 4, "NT_GNU_GOLD_VERSION");
+    // const std::map<boost::uint32_t, std::string> type_map = boost::assign::map_list_of
+    //     ( 1, "NT_GNU_ABI_TAG")
+    //     ( 2, "NT_GNU_HWCAP")
+    //     ( 3, "NT_GNU_BUILD_ID")
+    //     ( 4, "NT_GNU_GOLD_VERSION");
 
-    const std::map<boost::uint32_t, std::string> abi_map = boost::assign::map_list_of
-        ( 0, "OS Linux")
-        ( 1, "OS GNU")
-        ( 2, "OS Solaris")
-        ( 3, "OS FreeBSD");
+    const std::map<std::uint32_t, std::string> type_map = {
+    {1, "NT_GNU_ABI_TAG"},
+    {2, "NT_GNU_HWCAP"},
+    {3, "NT_GNU_BUILD_ID"},
+    {4, "NT_GNU_GOLD_VERSION"}
+    };
 
-    std::string parse_abi(const char* p_data, boost::uint32_t p_size)
+    // const std::map<boost::uint32_t, std::string> abi_map = boost::assign::map_list_of
+    //     ( 0, "OS Linux")
+    //     ( 1, "OS GNU")
+    //     ( 2, "OS Solaris")
+    //     ( 3, "OS FreeBSD");
+
+    const std::map<std::uint32_t, std::string> abi_map = {
+    {0, "OS Linux"},
+    {1, "OS GNU"},
+    {2, "OS Solaris"},
+    {3, "OS FreeBSD"}
+    };
+
+    // std::string parse_abi(const char* p_data, boost::uint32_t p_size)
+    std::string parse_abi(const char* p_data, std::uint32_t p_size)
     {
-        const boost::uint32_t* abi = reinterpret_cast<const boost::uint32_t*>(p_data);
+        // const boost::uint32_t* abi = reinterpret_cast<const boost::uint32_t*>(p_data);
+        const std::uint32_t* abi = reinterpret_cast<const std::uint32_t*>(p_data);
 
         if (p_size != 16)
         {
@@ -35,27 +54,42 @@ namespace
         }
 
         std::string return_value;
-        std::map<boost::uint32_t, std::string>::const_iterator abiIt = abi_map.find(abi[0]);
+        // std::map<boost::uint32_t, std::string>::const_iterator abiIt = abi_map.find(abi[0]);
+        std::map<std::uint32_t, std::string>::const_iterator abiIt = abi_map.find(abi[0]);
         if (abiIt != abi_map.end())
         {
             return_value.assign(abiIt->second);
         }
+        // else
+        // {
+        //     return_value.assign(boost::lexical_cast<std::string>(abi[0]));
+        // }
+        // return_value.push_back(' ');
+        // return_value.append(boost::lexical_cast<std::string>(abi[1]));
+        // return_value.push_back('.');
+        // return_value.append(boost::lexical_cast<std::string>(abi[2]));
+        // return_value.push_back('.');
+        // return_value.append(boost::lexical_cast<std::string>(abi[3]));
+        // return return_value;
         else
         {
-            return_value.assign(boost::lexical_cast<std::string>(abi[0]));
+            return_value.assign(std::to_string(abi[0]));
         }
         return_value.push_back(' ');
-        return_value.append(boost::lexical_cast<std::string>(abi[1]));
+        return_value.append(std::to_string(abi[1]));
         return_value.push_back('.');
-        return_value.append(boost::lexical_cast<std::string>(abi[2]));
+        return_value.append(std::to_string(abi[2]));
         return_value.push_back('.');
-        return_value.append(boost::lexical_cast<std::string>(abi[3]));
+        return_value.append(std::to_string(abi[3]));
         return return_value;
+
     }
 }
 
-NoteSegment::NoteSegment(const char* p_start, boost::uint32_t p_offset,
-                         boost::uint32_t p_size, elf::section_type p_type) :
+// NoteSegment::NoteSegment(const char* p_start, boost::uint32_t p_offset,
+//                          boost::uint32_t p_size, elf::section_type p_type) :
+NoteSegment::NoteSegment(const char* p_start, std::uint32_t p_offset,
+                         std::uint32_t p_size, elf::section_type p_type) :
     SegmentType(p_start, p_offset, p_size, p_type),
     m_note(NULL),
     m_name(),
@@ -69,7 +103,8 @@ NoteSegment::NoteSegment(const char* p_start, boost::uint32_t p_offset,
                       m_note->m_nameSize - 1);
     }
 
-    std::map<boost::uint32_t, std::string>::const_iterator typeIt = type_map.find(m_note->m_type);
+    // std::map<boost::uint32_t, std::string>::const_iterator typeIt = type_map.find(m_note->m_type);
+    std::map<std::uint32_t, std::string>::const_iterator typeIt = type_map.find(m_note->m_type);
     if (typeIt != type_map.end())
     {
         m_noteType.assign(typeIt->second);

--- a/src/segment_types/note_segment.hpp
+++ b/src/segment_types/note_segment.hpp
@@ -1,10 +1,11 @@
+//boost free
 #ifndef NOTE_SEGMENT_HPP
 #define NOTE_SEGMENT_HPP
 
 #include "segment_type.hpp"
 
 #include <string>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 namespace elf
@@ -29,8 +30,10 @@ public:
      * \param[in] p_size the size of this segment
      * \param[in] p_type elf::k_note
      */
-    NoteSegment(const char* start, boost::uint32_t p_offset,
-                boost::uint32_t p_size, elf::section_type p_type);
+    // NoteSegment(const char* start, boost::uint32_t p_offset,
+    //             boost::uint32_t p_size, elf::section_type p_type);
+    NoteSegment(const char* start, std::uint32_t p_offset,
+                std::uint32_t p_size, elf::section_type p_type);
 
     //nothing of note (lol)
     ~NoteSegment();

--- a/src/segment_types/readonly_segment.cpp
+++ b/src/segment_types/readonly_segment.cpp
@@ -1,3 +1,4 @@
+//boost free
 #include "readonly_segment.hpp"
 
 #include <boost/assign.hpp>
@@ -8,16 +9,20 @@
 
 #include <sstream>
 
-ReadOnlySegment::ReadOnlySegment(const char* start, boost::uint32_t p_offset,
-                                 boost::uint32_t p_size, elf::section_type p_type) :
+// ReadOnlySegment::ReadOnlySegment(const char* start, boost::uint32_t p_offset,
+//                                  boost::uint32_t p_size, elf::section_type p_type) :
+ReadOnlySegment::ReadOnlySegment(const char* start, std::uint32_t p_offset,
+                                 std::uint32_t p_size, elf::section_type p_type) :
     SegmentType(start, p_offset, p_size, p_type),
     m_asciiStrings()
 {
     std::string current;
     const char* readOnly = start + p_offset;
-    for (boost::uint32_t i = 0; i < p_size; ++i)
+    // for (boost::uint32_t i = 0; i < p_size; ++i)
+    for (std::uint32_t i = 0; i < p_size; ++i)
     {
-        if (isprint(static_cast<boost::uint8_t>(readOnly[i])))
+        // if (isprint(static_cast<boost::uint8_t>(readOnly[i])))
+        if (isprint(static_cast<std::uint8_t>(readOnly[i])))
         {
             current.push_back(readOnly[i]);
         }
@@ -43,14 +48,16 @@ std::string ReadOnlySegment::printToStdOut() const
                  << ", size=" << std::dec << m_size << ", strings="
                  << m_asciiStrings.size() << ")\n";
 
-    BOOST_FOREACH(const std::string& p_ascii, m_asciiStrings)
+    // BOOST_FOREACH(const std::string& p_ascii, m_asciiStrings)
+    for(const std::string& p_ascii : m_asciiStrings)
     {
         return_value << "\tString=\"" << p_ascii << "\"\n";
     }
     return return_value.str();
 }
 
-void ReadOnlySegment::evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+// void ReadOnlySegment::evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+void ReadOnlySegment::evaluate(std::vector<std::pair<std::int32_t, std::string> >& p_reasons,
                                std::map<elf::Capabilties, std::set<std::string> >&) const
 {
     if (m_asciiStrings.empty())

--- a/src/segment_types/readonly_segment.hpp
+++ b/src/segment_types/readonly_segment.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef READONLY_SEGMENT_HPP
 #define READONLY_SEGMENT_HPP
 
@@ -6,7 +7,7 @@
 #include <set>
 #include <vector>
 #include <string>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 /*!
@@ -23,8 +24,10 @@ public:
      * \param[in] p_size the size of this segment
      * \param[in] p_type the type of this segment
      */
-    ReadOnlySegment(const char* p_start, boost::uint32_t p_offset,
-                    boost::uint32_t p_size, elf::section_type p_type);
+    // ReadOnlySegment(const char* p_start, boost::uint32_t p_offset,
+    //                 boost::uint32_t p_size, elf::section_type p_type);
+    ReadOnlySegment(const char* p_start, std::uint32_t p_offset,
+                    std::uint32_t p_size, elf::section_type p_type);
 
     //! Nothing of note
     ~ReadOnlySegment();
@@ -34,7 +37,8 @@ public:
      * \param[in] p_reasons the scoring vector to put the scores into
      * \param[in] unused capabilties set
      */
-    void evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+    // void evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+    void evaluate(std::vector<std::pair<std::int32_t, std::string> >& p_reasons,
                   std::map<elf::Capabilties, std::set<std::string> >&) const;
 
     //! \return the string representation of the read only segment

--- a/src/segment_types/segment_type.cpp
+++ b/src/segment_types/segment_type.cpp
@@ -1,7 +1,10 @@
+//boost free
 #include "segment_type.hpp"
 
-SegmentType::SegmentType (const char*, boost::uint32_t p_offset,
-                  boost::uint32_t p_size, elf::section_type p_type) :
+// SegmentType::SegmentType (const char*, boost::uint32_t p_offset,
+//                   boost::uint32_t p_size, elf::section_type p_type) :
+SegmentType::SegmentType (const char*, std::uint32_t p_offset,
+                  std::uint32_t p_size, elf::section_type p_type) :
     m_type(p_type),
     m_offset(p_offset),
     m_size(p_size),
@@ -18,7 +21,8 @@ elf::section_type SegmentType::getType() const
     return m_type;
 }
 
-boost::uint32_t SegmentType::getOffset() const
+// boost::uint32_t SegmentType::getOffset() const
+std::uint32_t SegmentType::getOffset() const
 {
     return m_offset;
 }

--- a/src/segment_types/segment_type.hpp
+++ b/src/segment_types/segment_type.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef SEGMENTTYPE_HPP
 #define SEGMENTTYPE_HPP
 
@@ -5,7 +6,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 #include "../structures/sectionheader.hpp"
@@ -27,8 +28,10 @@ public:
      * \param[in] p_type the type of segment being created
      * \note p_start is currently not used, but is there for future use
      */
-    SegmentType(const char* p_start, boost::uint32_t p_offset,
-                boost::uint32_t p_size, elf::section_type p_type);
+    // SegmentType(const char* p_start, boost::uint32_t p_offset,
+    SegmentType(const char* p_start, std::uint32_t p_offset,
+                // boost::uint32_t p_size, elf::section_type p_type);
+                std::uint32_t p_size, elf::section_type p_type);
 
     //! Nothing of note
     virtual ~SegmentType();
@@ -37,7 +40,8 @@ public:
     elf::section_type getType() const;
 
     //! \return the offset to this segment
-    boost::uint32_t getOffset() const;
+    // boost::uint32_t getOffset() const;
+    std::uint32_t getOffset() const;
 
     /*!
      * Stores this segments corresponding string table if one exists and the
@@ -52,7 +56,8 @@ public:
      * \param[in,out] unused the reasons vector
      * \param[in,out] unused the capabilities vector
      */
-    virtual void evaluate(std::vector<std::pair<boost::int32_t, std::string> >&,
+    // virtual void evaluate(std::vector<std::pair<boost::int32_t, std::string> >&,
+    virtual void evaluate(std::vector<std::pair<std::int32_t, std::string> >&,
                           std::map<elf::Capabilties, std::set<std::string> >&) const
     {
     }
@@ -72,10 +77,12 @@ protected:
     elf::section_type m_type;
 
     //! The offset to this segment
-    boost::uint32_t m_offset;
+    // boost::uint32_t m_offset;
+    std::uint32_t m_offset;
 
     //! The size of this segment
-    boost::uint32_t m_size;
+    // boost::uint32_t m_size;
+    std::uint32_t m_size;
 
     //! A pointer to a string segment
     SegmentType* m_strings;

--- a/src/segment_types/strtable_segment.cpp
+++ b/src/segment_types/strtable_segment.cpp
@@ -1,9 +1,10 @@
+//boost free
 #include "strtable_segment.hpp"
 
 #include <cstring>
 #include <sstream>
 
-#include <boost/foreach.hpp>
+//#include <boost/foreach.hpp>
 #include <algorithm>
 
 #ifndef WINDOWS
@@ -11,8 +12,10 @@
 #endif
 
 StringTableSegment::StringTableSegment(const char* start,
-                                       boost::uint32_t p_offset,
-                                       boost::uint32_t p_size,
+                                    //    boost::uint32_t p_offset,
+                                    //    boost::uint32_t p_size,
+                                       std::uint32_t p_offset,
+                                       std::uint32_t p_size,
                                        elf::section_type p_type) :
     SegmentType(start, p_offset, p_size, p_type),
     m_stringsSet(),
@@ -67,7 +70,8 @@ std::string StringTableSegment::printToStdOut() const
         << ", size=" << std::dec << m_size << ", entries="
         << m_stringsSet.size() << ")\n";
 
-    BOOST_FOREACH(const std::string& p_ascii, m_stringsSet)
+    // BOOST_FOREACH(const std::string& p_ascii, m_stringsSet)
+    for(const std::string& p_ascii : m_stringsSet)
     {
         return_value << "\tString=\"" << p_ascii << "\"\n";
     }

--- a/src/segment_types/strtable_segment.hpp
+++ b/src/segment_types/strtable_segment.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef STRINGTABLE_SEGMENT_HPP
 #define STRINGTABLE_SEGMENT_HPP
 
@@ -5,7 +6,7 @@
 
 #include <set>
 #include <string>
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 /*!
@@ -22,8 +23,10 @@ public:
      * \param[in] p_size the size of the segment
      * \param[in] p_type the type of segment
      */
-    StringTableSegment(const char* p_start, boost::uint32_t p_offset,
-                       boost::uint32_t p_size, elf::section_type p_type);
+    // StringTableSegment(const char* p_start, boost::uint32_t p_offset,
+    //                    boost::uint32_t p_size, elf::section_type p_type);
+    StringTableSegment(const char* p_start, std::uint32_t p_offset,
+                       std::uint32_t p_size, elf::section_type p_type);
 
     //! nothing of note
     ~StringTableSegment();

--- a/src/structures/capabilities.hpp
+++ b/src/structures/capabilities.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef CAPABILITIES_HPP
 #define CAPABILITIES_HPP
 

--- a/src/structures/dynamicstruct.hpp
+++ b/src/structures/dynamicstruct.hpp
@@ -1,10 +1,11 @@
+//boost free
 #ifndef DYNAMICSTRUCT_HPP
 #define DYNAMICSTRUCT_HPP
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
-#include <boost/static_assert.hpp>
+//#include <boost/static_assert.hpp>
 #include <cassert>
 
 #include <sstream>
@@ -16,27 +17,36 @@ namespace elf
     {
         struct dynamic_32
         {
-            boost::uint32_t m_tag;
+            // boost::uint32_t m_tag;
+            std::uint32_t m_tag;
             union
             {
-                boost::uint32_t m_val;
-                boost::uint32_t m_ptr;
+                // boost::uint32_t m_val;
+                std::uint32_t m_val;
+                // boost::uint32_t m_ptr;
+                std::uint32_t m_ptr;
             };
         };
 
-        BOOST_STATIC_ASSERT(8 == sizeof(dynamic_32));
+        // BOOST_STATIC_ASSERT(8 == sizeof(dynamic_32));
+        static_assert(8 == sizeof(dynamic_32), "Size of dynamic_32 must be 8 bytes");
+
 
         struct dynamic_64
         {
-            boost::uint64_t m_tag;
+            // boost::uint64_t m_tag;
+            std::uint64_t m_tag;
             union
             {
-                boost::uint64_t m_val;
-                boost::uint64_t m_ptr;
+                // boost::uint64_t m_val;
+                // boost::uint64_t m_ptr;
+                std::uint64_t m_val;
+                std::uint64_t m_ptr;
             };
         };
 
-        BOOST_STATIC_ASSERT(16 == sizeof(dynamic_64));
+        // BOOST_STATIC_ASSERT(16 == sizeof(dynamic_64));
+        static_assert(16 == sizeof(dynamic_64), "Size of dynamic_64 must be 16 bytes");
 
         enum tag
         {

--- a/src/structures/elfheader.hpp
+++ b/src/structures/elfheader.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef ELF_HEADER_HPP
 #define ELF_HEADER_HPP
 
@@ -48,71 +49,119 @@ namespace elf
     {
         union
         {
-            boost::uint8_t m_ident[16];
+            // boost::uint8_t m_ident[16];
+            std::uint8_t m_ident[16];
             struct
             {
-                boost::uint8_t m_magic0;
-                boost::uint8_t m_magic1;
-                boost::uint8_t m_magic2;
-                boost::uint8_t m_magic3;
-                boost::uint8_t m_class;
-                boost::uint8_t m_encoding;
-                boost::uint8_t m_fileversion;
-                boost::uint8_t m_os;
-                boost::uint8_t m_abi;
+                // boost::uint8_t m_magic0;
+                // boost::uint8_t m_magic1;
+                // boost::uint8_t m_magic2;
+                // boost::uint8_t m_magic3;
+                // boost::uint8_t m_class;
+                // boost::uint8_t m_encoding;
+                // boost::uint8_t m_fileversion;
+                // boost::uint8_t m_os;
+                // boost::uint8_t m_abi;
+                std::uint8_t m_magic0;
+                std::uint8_t m_magic1;
+                std::uint8_t m_magic2;
+                std::uint8_t m_magic3;
+                std::uint8_t m_class;
+                std::uint8_t m_encoding;
+                std::uint8_t m_fileversion;
+                std::uint8_t m_os;
+                std::uint8_t m_abi;
             };
         };
-        boost::uint16_t m_type;
-        boost::uint16_t m_machine;
-        boost::uint32_t m_version;
-        boost::uint32_t m_entry;
-        boost::uint32_t m_phoff;
-        boost::uint32_t m_shoff;
-        boost::uint32_t m_flags;
-        boost::uint16_t m_ehsize;
-        boost::uint16_t m_phentsize;
-        boost::uint16_t m_phnum;
-        boost::uint16_t m_shentsize;
-        boost::uint16_t m_shnum;
-        boost::uint16_t m_shtrndx;
+        // boost::uint16_t m_type;
+        // boost::uint16_t m_machine;
+        // boost::uint32_t m_version;
+        // boost::uint32_t m_entry;
+        // boost::uint32_t m_phoff;
+        // boost::uint32_t m_shoff;
+        // boost::uint32_t m_flags;
+        // boost::uint16_t m_ehsize;
+        // boost::uint16_t m_phentsize;
+        // boost::uint16_t m_phnum;
+        // boost::uint16_t m_shentsize;
+        // boost::uint16_t m_shnum;
+        // boost::uint16_t m_shtrndx;
+        std::uint16_t m_type;
+        std::uint16_t m_machine;
+        std::uint32_t m_version;
+        std::uint32_t m_entry;
+        std::uint32_t m_phoff;
+        std::uint32_t m_shoff;
+        std::uint32_t m_flags;
+        std::uint16_t m_ehsize;
+        std::uint16_t m_phentsize;
+        std::uint16_t m_phnum;
+        std::uint16_t m_shentsize;
+        std::uint16_t m_shnum;
+        std::uint16_t m_shtrndx;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(elf_header_32) == 52);
+    //BOOST_STATIC_ASSERT(sizeof(elf_header_32) == 52);
+    static_assert(52 == sizeof(elf_header_32), "Size of elf_header_32 must be 52 bytes");
 
     struct elf_header_64
     {
         union
         {
-            boost::uint8_t m_ident[16];
+            // boost::uint8_t m_ident[16];
+            std::uint8_t m_ident[16];
             struct
             {
-                boost::uint8_t m_magic0;
-                boost::uint8_t m_magic1;
-                boost::uint8_t m_magic2;
-                boost::uint8_t m_magic3;
-                boost::uint8_t m_class;
-                boost::uint8_t m_encoding;
-                boost::uint8_t m_fileversion;
-                boost::uint8_t m_os;
-                boost::uint8_t m_abi;
+                // boost::uint8_t m_magic0;
+                // boost::uint8_t m_magic1;
+                // boost::uint8_t m_magic2;
+                // boost::uint8_t m_magic3;
+                // boost::uint8_t m_class;
+                // boost::uint8_t m_encoding;
+                // boost::uint8_t m_fileversion;
+                // boost::uint8_t m_os;
+                // boost::uint8_t m_abi;
+                std::uint8_t m_magic0;
+                std::uint8_t m_magic1;
+                std::uint8_t m_magic2;
+                std::uint8_t m_magic3;
+                std::uint8_t m_class;
+                std::uint8_t m_encoding;
+                std::uint8_t m_fileversion;
+                std::uint8_t m_os;
+                std::uint8_t m_abi;
             };
         };
-        boost::uint16_t m_type;
-        boost::uint16_t m_machine;
-        boost::uint32_t m_version;
-        boost::uint64_t m_entry;
-        boost::uint64_t m_phoff;
-        boost::uint64_t m_shoff;
-        boost::uint32_t m_flags;
-        boost::uint16_t m_ehsize;
-        boost::uint16_t m_phentsize;
-        boost::uint16_t m_phnum;
-        boost::uint16_t m_shentsize;
-        boost::uint16_t m_shnum;
-        boost::uint16_t m_shtrndx;
+        // boost::uint16_t m_type;
+        // boost::uint16_t m_machine;
+        // boost::uint32_t m_version;
+        // boost::uint64_t m_entry;
+        // boost::uint64_t m_phoff;
+        // boost::uint64_t m_shoff;
+        // boost::uint32_t m_flags;
+        // boost::uint16_t m_ehsize;
+        // boost::uint16_t m_phentsize;
+        // boost::uint16_t m_phnum;
+        // boost::uint16_t m_shentsize;
+        // boost::uint16_t m_shnum;
+        // boost::uint16_t m_shtrndx;
+        std::uint16_t m_type;
+        std::uint16_t m_machine;
+        std::uint32_t m_version;
+        std::uint64_t m_entry;
+        std::uint64_t m_phoff;
+        std::uint64_t m_shoff;
+        std::uint32_t m_flags;
+        std::uint16_t m_ehsize;
+        std::uint16_t m_phentsize;
+        std::uint16_t m_phnum;
+        std::uint16_t m_shentsize;
+        std::uint16_t m_shnum;
+        std::uint16_t m_shtrndx;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(elf_header_64) == 64);
+    //BOOST_STATIC_ASSERT(sizeof(elf_header_64) == 64);
+    static_assert(64 == sizeof(elf_header_64), "Size of elf_header_64 must be 64 bytes");
     #pragma pack(pop)
 }
 

--- a/src/structures/noteformat.hpp
+++ b/src/structures/noteformat.hpp
@@ -1,3 +1,4 @@
+//boost free
 #ifndef NOTE_FORMAT_HPP
 #define NOTE_FORMAT_HPP
 
@@ -6,9 +7,12 @@ namespace elf
     #pragma pack(push, 1)
     struct note
     {
-        boost::uint32_t m_nameSize;
-        boost::uint32_t m_descSize;
-        boost::uint32_t m_type;
+        // boost::uint32_t m_nameSize;
+        // boost::uint32_t m_descSize;
+        // boost::uint32_t m_type;
+        std::uint32_t m_nameSize;
+        std::uint32_t m_descSize;
+        std::uint32_t m_type;
     };
     #pragma pack(pop)
 }

--- a/src/structures/programheader.hpp
+++ b/src/structures/programheader.hpp
@@ -1,41 +1,61 @@
+//boost free
 #ifndef PROGRAM_HEADER_HPP
 #define PROGRAM_HEADER_HPP
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
-#include <boost/static_assert.hpp>
+//#include <boost/static_assert.hpp>
 #include <cassert>
 
 namespace elf
 {
     struct program_header_32
     {
-        boost::uint32_t m_type;
-        boost::uint32_t m_offset;
-        boost::uint32_t m_vaddr;
-        boost::uint32_t m_paddr;
-        boost::uint32_t m_filesz;
-        boost::uint32_t m_memsz;
-        boost::uint32_t m_flags;
-        boost::uint32_t m_align;
+        // boost::uint32_t m_type;
+        // boost::uint32_t m_offset;
+        // boost::uint32_t m_vaddr;
+        // boost::uint32_t m_paddr;
+        // boost::uint32_t m_filesz;
+        // boost::uint32_t m_memsz;
+        // boost::uint32_t m_flags;
+        // boost::uint32_t m_align;
+        std::uint32_t m_type;
+        std::uint32_t m_offset;
+        std::uint32_t m_vaddr;
+        std::uint32_t m_paddr;
+        std::uint32_t m_filesz;
+        std::uint32_t m_memsz;
+        std::uint32_t m_flags;
+        std::uint32_t m_align;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(program_header_32) == 32);
+    //BOOST_STATIC_ASSERT(sizeof(program_header_32) == 32);
+    static_assert(32 == sizeof(program_header_32), "Size of program_header_32 must be 32 bytes");
+
 
     struct program_header_64
     {
-        boost::uint32_t m_type;
-        boost::uint32_t m_flags;
-        boost::uint64_t m_offset;
-        boost::uint64_t m_vaddr;
-        boost::uint64_t m_paddr;
-        boost::uint64_t m_filesz;
-        boost::uint64_t m_memsz;
-        boost::uint64_t m_align;
+        // boost::uint32_t m_type;
+        // boost::uint32_t m_flags;
+        // boost::uint64_t m_offset;
+        // boost::uint64_t m_vaddr;
+        // boost::uint64_t m_paddr;
+        // boost::uint64_t m_filesz;
+        // boost::uint64_t m_memsz;
+        // boost::uint64_t m_align;
+        std::uint32_t m_type;
+        std::uint32_t m_flags;
+        std::uint64_t m_offset;
+        std::uint64_t m_vaddr;
+        std::uint64_t m_paddr;
+        std::uint64_t m_filesz;
+        std::uint64_t m_memsz;
+        std::uint64_t m_align;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(program_header_64) == 56);
+    //BOOST_STATIC_ASSERT(sizeof(program_header_64) == 56);
+    static_assert(56 == sizeof(program_header_64), "Size of program_header_64 must be 56 bytes");
 
     enum programheader_type
     {

--- a/src/structures/relocation.hpp
+++ b/src/structures/relocation.hpp
@@ -1,48 +1,63 @@
+//boost free
 #ifndef RELOCATION_HPP
 #define RELOCATION_HPP
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
-#include <boost/static_assert.hpp>
+//#include <boost/static_assert.hpp>
 #include <cassert>
 
 namespace elf
 {
     struct relocation_32
     {
-        boost::uint32_t m_offset;
-        boost::uint32_t m_info;
+        // boost::uint32_t m_offset;
+        // boost::uint32_t m_info;
+        std::uint32_t m_offset;
+        std::uint32_t m_info;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(relocation_32) == 8);
+    //BOOST_STATIC_ASSERT(sizeof(relocation_32) == 8);
+    static_assert(8 == sizeof(relocation_32), "Size of relocation_32 must be 8 bytes");
 
     struct relocation_64
     {
-        boost::uint64_t m_offset;
-        boost::uint64_t m_info;
+        // boost::uint64_t m_offset;
+        // boost::uint64_t m_info;
+        std::uint64_t m_offset;
+        std::uint64_t m_info;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(relocation_64) == 16);
+    //BOOST_STATIC_ASSERT(sizeof(relocation_64) == 16);
+    static_assert(16 == sizeof(relocation_64), "Size of relocation_64 must be 16 bytes");
 
     #pragma pack(push, 1)
     struct rela_32
     {
-        boost::uint32_t m_offset;
-        boost::uint32_t m_info;
-        boost::uint32_t m_addend;
+        // boost::uint32_t m_offset;
+        // boost::uint32_t m_info;
+        // boost::uint32_t m_addend;
+        std::uint32_t m_offset;
+        std::uint32_t m_info;
+        std::uint32_t m_addend;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(rela_32) == 12);
+    //BOOST_STATIC_ASSERT(sizeof(rela_32) == 12);
+    static_assert(12 == sizeof(rela_32), "Size of rela_32 must be 12 bytes");
 
     struct rela_64
     {
-        boost::uint64_t m_offset;
-        boost::uint64_t m_info;
-        boost::uint64_t m_addend;
+        // boost::uint64_t m_offset;
+        // boost::uint64_t m_info;
+        // boost::uint64_t m_addend;
+        std::uint64_t m_offset;
+        std::uint64_t m_info;
+        std::uint64_t m_addend;
     };
     #pragma pack(pop)
-    BOOST_STATIC_ASSERT(sizeof(rela_64) == 24);
+    //BOOST_STATIC_ASSERT(sizeof(rela_64) == 24);
+    static_assert(24 == sizeof(rela_64), "Size of rela_64 must be 24 bytes");
 }
 
 #endif

--- a/src/structures/sectionheader.hpp
+++ b/src/structures/sectionheader.hpp
@@ -1,45 +1,69 @@
+//boost free
 #ifndef SECTION_HEADER_HPP
 #define SECTION_HEADER_HPP
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
-#include <boost/static_assert.hpp>
+//#include <boost/static_assert.hpp>
 #include <cassert>
 
 namespace elf
 {
     struct section_header_32
     {
-        boost::uint32_t m_name;
-        boost::uint32_t m_type;
-        boost::uint32_t m_flags;
-        boost::uint32_t m_addr;
-        boost::uint32_t m_offset;
-        boost::uint32_t m_size;
-        boost::uint32_t m_link;
-        boost::uint32_t m_info;
-        boost::uint32_t m_addralign;
-        boost::uint32_t m_entsize;
+        // boost::uint32_t m_name;
+        // boost::uint32_t m_type;
+        // boost::uint32_t m_flags;
+        // boost::uint32_t m_addr;
+        // boost::uint32_t m_offset;
+        // boost::uint32_t m_size;
+        // boost::uint32_t m_link;
+        // boost::uint32_t m_info;
+        // boost::uint32_t m_addralign;
+        // boost::uint32_t m_entsize;
+        std::uint32_t m_name;
+        std::uint32_t m_type;
+        std::uint32_t m_flags;
+        std::uint32_t m_addr;
+        std::uint32_t m_offset;
+        std::uint32_t m_size;
+        std::uint32_t m_link;
+        std::uint32_t m_info;
+        std::uint32_t m_addralign;
+        std::uint32_t m_entsize;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(section_header_32) == 40);
+    //BOOST_STATIC_ASSERT(sizeof(section_header_32) == 40);
+    static_assert(40 == sizeof(section_header_32), "Size of section_header_32 must be 40 bytes");
+    
 
     struct section_header_64
     {
-        boost::uint32_t m_name;
-        boost::uint32_t m_type;
-        boost::uint64_t m_flags;
-        boost::uint64_t m_addr;
-        boost::uint64_t m_offset;
-        boost::uint64_t m_size;
-        boost::uint32_t m_link;
-        boost::uint32_t m_info;
-        boost::uint64_t m_addralign;
-        boost::uint64_t m_entsize;
+        // boost::uint32_t m_name;
+        // boost::uint32_t m_type;
+        // boost::uint64_t m_flags;
+        // boost::uint64_t m_addr;
+        // boost::uint64_t m_offset;
+        // boost::uint64_t m_size;
+        // boost::uint32_t m_link;
+        // boost::uint32_t m_info;
+        // boost::uint64_t m_addralign;
+        // boost::uint64_t m_entsize;
+        std::uint32_t m_name;
+        std::uint32_t m_type;
+        std::uint64_t m_flags;
+        std::uint64_t m_addr;
+        std::uint64_t m_offset;
+        std::uint64_t m_size;
+        std::uint32_t m_link;
+        std::uint32_t m_info;
+        std::uint64_t m_addralign;
+        std::uint64_t m_entsize;
     };
 
-    BOOST_STATIC_ASSERT(sizeof(section_header_64) == 64);
+    //BOOST_STATIC_ASSERT(sizeof(section_header_64) == 64);
+    static_assert(64 == sizeof(section_header_64), "Size of section_header_64 must be 64 bytes");
 
     enum section_type
     {

--- a/src/structures/symtable_entry.hpp
+++ b/src/structures/symtable_entry.hpp
@@ -1,12 +1,13 @@
+//boost free
 #ifndef SYMTABLE_ENTRY_HPP
 #define SYMTABLE_ENTRY_HPP
 
 #include <string>
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
-#include <boost/static_assert.hpp>
+//#include <boost/static_assert.hpp>
 #include <cassert>
 
 namespace elf
@@ -16,27 +17,41 @@ namespace elf
         #pragma pack(push, 1)
         struct symtable_entry32
         {
-            boost::uint32_t m_name;
-            boost::uint32_t m_address;
-            boost::uint32_t m_size;
-            boost::uint8_t m_info;
-            boost::uint8_t m_other;
-            boost::uint16_t m_shndx;
+            // boost::uint32_t m_name;
+            // boost::uint32_t m_address;
+            // boost::uint32_t m_size;
+            // boost::uint8_t m_info;
+            // boost::uint8_t m_other;
+            // boost::uint16_t m_shndx;
+            std::uint32_t m_name;
+            std::uint32_t m_address;
+            std::uint32_t m_size;
+            std::uint8_t m_info;
+            std::uint8_t m_other;
+            std::uint16_t m_shndx;
         };
 
-        BOOST_STATIC_ASSERT(sizeof(symtable_entry32) == 16);
+        //BOOST_STATIC_ASSERT(sizeof(symtable_entry32) == 16);
+        static_assert(16 == sizeof(symtable_entry32), "Size of symtable_entry32 must be 16 bytes");
 
         struct symtable_entry64
         {
-            boost::uint32_t m_name;
-            boost::uint8_t m_info;
-            boost::uint8_t m_other;
-            boost::uint16_t m_shndx;
-            boost::uint64_t m_address;
-            boost::uint64_t m_size;
+            // boost::uint32_t m_name;
+            // boost::uint8_t m_info;
+            // boost::uint8_t m_other;
+            // boost::uint16_t m_shndx;
+            // boost::uint64_t m_address;
+            // boost::uint64_t m_size;
+            std::uint32_t m_name;
+            std::uint8_t m_info;
+            std::uint8_t m_other;
+            std::uint16_t m_shndx;
+            std::uint64_t m_address;
+            std::uint64_t m_size;
         };
 
-        BOOST_STATIC_ASSERT(sizeof(symtable_entry64) == 24);
+        //BOOST_STATIC_ASSERT(sizeof(symtable_entry64) == 24);
+        static_assert(24 == sizeof(symtable_entry64), "Size of symtable_entry64 must be 24 bytes");
         #pragma pack(pop)
 
         enum binding

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -304,7 +304,8 @@ std::string Symbols::findSymbol(std::uint64_t p_address) const
     return "";
 }
 
-void Symbols::evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+// void Symbols::evaluate(std::vector<std::pair<boost::int32_t, std::string> >& p_reasons,
+void Symbols::evaluate(std::vector<std::pair<std::int32_t, std::string> >& p_reasons,
                        std::map<elf::Capabilties, std::set<std::string> >& p_capabilities) const
 {
     (void)p_reasons; //appears to be unused

--- a/src/tests/ls_tests.cpp
+++ b/src/tests/ls_tests.cpp
@@ -1,3 +1,4 @@
+//boost free
 #include "gtest/gtest.h"
 #include "../elfparser.hpp"
 #include "../abstract_programheader.hpp"
@@ -8,7 +9,7 @@
 #include "../dynamicsection.hpp"
 #include "../symbols.hpp"
 
-#include <boost/foreach.hpp>
+//#include <boost/foreach.hpp>
 #include <algorithm>
 
 class LSTest : public testing::Test
@@ -181,6 +182,26 @@ TEST_F(LSTest, Thirtytwo_Intel_ls)
     EXPECT_EQ(114, m_parser.getSegments().getDynamicSection().getSymbolTableSize());
     EXPECT_EQ(130, m_parser.getSegments().getDynamicSymbols().getSymbols().size());
 }
+// /*
+// TEST_F(LSTest, Sixtyfour_Intel_ls_upx)
+// {
+//     m_parser.parse("../test_files/64_intel_ls_upx");
+//     m_parser.evaluate();
+//     EXPECT_TRUE(0 > m_parser.getScore());
+//     ASSERT_FALSE(m_parser.m_reasons.empty());
+
+//     bool found_probably_packed = false;
+//     for(std::vector<std::pair<boost::int32_t, std::string> >::const_iterator reasons = m_parser.m_reasons.begin();
+//         reasons != m_parser.m_reasons.end(); ++reasons)
+//     {
+//         if (reasons->second == "Probably packed")
+//         {
+//             found_probably_packed = true;
+//         }
+//     }
+//     EXPECT_TRUE(found_probably_packed);
+// }
+// */
 /*
 TEST_F(LSTest, Sixtyfour_Intel_ls_upx)
 {
@@ -190,7 +211,7 @@ TEST_F(LSTest, Sixtyfour_Intel_ls_upx)
     ASSERT_FALSE(m_parser.m_reasons.empty());
 
     bool found_probably_packed = false;
-    for(std::vector<std::pair<boost::int32_t, std::string> >::const_iterator reasons = m_parser.m_reasons.begin();
+    for(std::vector<std::pair<std::int32_t, std::string> >::const_iterator reasons = m_parser.m_reasons.begin();
         reasons != m_parser.m_reasons.end(); ++reasons)
     {
         if (reasons->second == "Probably packed")

--- a/src/tests/tiny_tests.cpp
+++ b/src/tests/tiny_tests.cpp
@@ -1,3 +1,4 @@
+//boost free
 #include "gtest/gtest.h"
 #include "../elfparser.hpp"
 #include "../abstract_programheader.hpp"
@@ -8,7 +9,7 @@
 #include "../dynamicsection.hpp"
 #include "../symbols.hpp"
 
-#include <boost/foreach.hpp>
+//#include <boost/foreach.hpp>
 #include <algorithm>
 
 class TinyTest : public testing::Test

--- a/src/ui/inttablewidget.cpp
+++ b/src/ui/inttablewidget.cpp
@@ -1,19 +1,22 @@
+//boost free
 #ifdef QT_GUI
 #include "inttablewidget.hpp"
 
 #include <string>
 #include <sstream>
 
-#include <boost/lexical_cast.hpp>
+//#include <boost/lexical_cast.hpp>
 #include <sstream>
 
-IntWidgetItem::IntWidgetItem(boost::uint64_t p_value, bool p_hex) :
+// IntWidgetItem::IntWidgetItem(boost::uint64_t p_value, bool p_hex) :
+IntWidgetItem::IntWidgetItem(std::uint64_t p_value, bool p_hex) :
     QTableWidgetItem(),
     m_value(p_value)
 {
     if (!p_hex)
     {
-        QString intValue(boost::lexical_cast<std::string>(m_value).c_str());
+        // QString intValue(boost::lexical_cast<std::string>(m_value).c_str());
+        QString intValue(std::to_string(m_value).c_str());
         setText(intValue);
     }
     else

--- a/src/ui/inttablewidget.hpp
+++ b/src/ui/inttablewidget.hpp
@@ -1,23 +1,26 @@
+//boost free
 #ifdef QT_GUI
 #ifndef INTENTRY_HPP
 #define INTENTRY_HPP
 
 #include <QTableWidgetItem>
 
-#include <boost/cstdint.hpp>
+//#include <boost/cstdint.hpp>
 #include <cstdint>
 
 class IntWidgetItem : public QTableWidgetItem
 {
 public:
-    IntWidgetItem(boost::uint64_t p_value, bool p_hex = false);
+    //IntWidgetItem(boost::uint64_t p_value, bool p_hex = false);
+    IntWidgetItem(std::uint64_t p_value, bool p_hex = false);
     ~IntWidgetItem();
 
     bool operator <(const QTableWidgetItem &other) const;
 
 private:
     //! the underlying value in int format
-    boost::uint64_t m_value;
+    // boost::uint64_t m_value;
+    std::uint64_t m_value;
 };
 
 #endif

--- a/src/ui/mainwindow.cpp
+++ b/src/ui/mainwindow.cpp
@@ -1,3 +1,4 @@
+//boost free
 #ifdef QT_GUI
 #include "mainwindow.h"
 #include "ui_mainwindow.h"
@@ -16,11 +17,11 @@
 
 #include <iostream>
 
-#include <boost/foreach.hpp>
-#include <boost/algorithm/string.hpp>
+//#include <boost/foreach.hpp>
+//#include <boost/algorithm/string.hpp>
 #include <algorithm>
 
-#include <boost/lexical_cast.hpp>
+//#include <boost/lexical_cast.hpp>
 #include <sstream>
 
 
@@ -88,113 +89,156 @@ void MainWindow::openFile()
         // Overview table
         QTableWidgetItem* tableItem = new QTableWidgetItem(QString(m_parser->getFilename().c_str()));
         m_ui->overviewTable->setItem(0, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getFileSize()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        // tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getFileSize()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getFileSize()).c_str()));
         m_ui->overviewTable->setItem(1, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getMD5().c_str()));
         m_ui->overviewTable->setItem(2, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getSha1().c_str()));
         m_ui->overviewTable->setItem(3, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getSha256().c_str()));
         m_ui->overviewTable->setItem(4, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getFamily().c_str()));
         m_ui->overviewTable->setItem(5, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
 
         // elf header view
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getMagic().c_str()));
         m_ui->headerTable->setItem(0, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getClass().c_str()));
         m_ui->headerTable->setItem(1, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getEncoding().c_str()));
         m_ui->headerTable->setItem(2, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getFileVersion().c_str()));
         m_ui->headerTable->setItem(3, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getOSABI().c_str()));
         m_ui->headerTable->setItem(4, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getABIVersion().c_str()));
         m_ui->headerTable->setItem(5, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getType().c_str()));
         m_ui->headerTable->setItem(6, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getMachine().c_str()));
         m_ui->headerTable->setItem(7, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getVersion().c_str()));
         m_ui->headerTable->setItem(8, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getEntryPointString().c_str()));
         m_ui->headerTable->setItem(9, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getProgramOffset()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getProgramOffset()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getProgramOffset()).c_str()));
         m_ui->headerTable->setItem(10, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getSectionOffset()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getSectionOffset()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getSectionOffset()).c_str()));
         m_ui->headerTable->setItem(11, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getFlags().c_str()));
         m_ui->headerTable->setItem(12, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
         tableItem = new QTableWidgetItem(QString(m_parser->getElfHeader().getEHSize().c_str()));
         m_ui->headerTable->setItem(13, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getProgramSize()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getProgramSize()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getProgramSize()).c_str()));
         m_ui->headerTable->setItem(14, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getProgramCount()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getProgramCount()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getProgramCount()).c_str()));
         m_ui->headerTable->setItem(15, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getSectionSize()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getSectionSize()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getSectionSize()).c_str()));
         m_ui->headerTable->setItem(16, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getSectionCount()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getSectionCount()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getSectionCount()).c_str()));
         m_ui->headerTable->setItem(17, 0, tableItem);
-        m_tableItems.push_back(tableItem);
-        tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getStringTableIndex()).c_str()));
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
+        //tableItem = new QTableWidgetItem(QString(boost::lexical_cast<std::string>(m_parser->getElfHeader().getStringTableIndex()).c_str()));
+        tableItem = new QTableWidgetItem(QString(std::to_string(m_parser->getElfHeader().getStringTableIndex()).c_str()));
         m_ui->headerTable->setItem(18, 0, tableItem);
-        m_tableItems.push_back(tableItem);
+        //m_tableItems.push_back(tableItem);
+        m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
 
         // sections table
-        boost::uint32_t i = 0;
+        // boost::uint32_t i = 0;
+        std::uint32_t i = 0;
         const std::vector<AbstractSectionHeader>& sections(m_parser->getSectionHeaders().getSections());
         m_ui->sectionsTable->setRowCount(sections.size());
         m_ui->sectionsTable->setSortingEnabled(false);
-        BOOST_FOREACH(const AbstractSectionHeader& section, sections)
+        // BOOST_FOREACH(const AbstractSectionHeader& section, sections)
+        for(const AbstractSectionHeader& section : sections)
         {
             tableItem = new IntWidgetItem(i);
             m_ui->sectionsTable->setItem(i, 0, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(section.getName().c_str()));
             m_ui->sectionsTable->setItem(i, 1, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(section.getTypeString().c_str()));
             m_ui->sectionsTable->setItem(i, 2, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(section.getFlagsString().c_str()));
             m_ui->sectionsTable->setItem(i, 3, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(section.getVirtAddress(), true);
             m_ui->sectionsTable->setItem(i, 4, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(section.getPhysOffset(), false);
             m_ui->sectionsTable->setItem(i, 5, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(section.getSize());
             m_ui->sectionsTable->setItem(i, 6, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(section.getLink());
             m_ui->sectionsTable->setItem(i, 7, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             ++i;
         }
         m_ui->sectionsTable->setSortingEnabled(true);
@@ -206,29 +250,37 @@ void MainWindow::openFile()
         const std::vector<AbstractProgramHeader>& programs(m_parser->getProgramHeaders().getProgramHeaders());
         m_ui->programsTable->setRowCount(programs.size());
         m_ui->programsTable->setSortingEnabled(false);
-        BOOST_FOREACH(const AbstractProgramHeader& program, programs)
+        // BOOST_FOREACH(const AbstractProgramHeader& program, programs)
+        for(const AbstractProgramHeader& program : programs)
         {
             tableItem = new QTableWidgetItem(QString(program.getName().c_str()));
             m_ui->programsTable->setItem(i, 0, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(program.getOffset());
             m_ui->programsTable->setItem(i, 1, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(program.getVirtualAddress(), true);
             m_ui->programsTable->setItem(i, 2, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(program.getPhysicalAddress(), true);
             m_ui->programsTable->setItem(i, 3, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(program.getFileSize());
             m_ui->programsTable->setItem(i, 4, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new IntWidgetItem(program.getMemorySize());
             m_ui->programsTable->setItem(i, 5, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(program.getFlagsString().c_str()));
             m_ui->programsTable->setItem(i, 6, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             ++i;
         }
         m_ui->programsTable->setSortingEnabled(true);
@@ -240,17 +292,21 @@ void MainWindow::openFile()
         const std::vector<AbstractSymbol>& allSymbols(m_parser->getSegments().getAllSymbols());
         m_ui->symbolsTable->setRowCount(allSymbols.size());
         m_ui->symbolsTable->setSortingEnabled(false);
-        BOOST_FOREACH(const AbstractSymbol& symbol, allSymbols)
+        // BOOST_FOREACH(const AbstractSymbol& symbol, allSymbols)
+        for(const AbstractSymbol& symbol : allSymbols)
         {
             tableItem = new QTableWidgetItem(QString(symbol.getTypeName().c_str()));
             m_ui->symbolsTable->setItem(i, 0, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(symbol.getBinding().c_str()));
             m_ui->symbolsTable->setItem(i, 1, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(symbol.getName().c_str()));
             m_ui->symbolsTable->setItem(i, 2, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             ++i;
         }
         m_ui->symbolsTable->setSortingEnabled(true);
@@ -330,31 +386,39 @@ void MainWindow::openFile()
             }
             m_ui->capabilitiesTree->addTopLevelItem(rootItem);
 
-            BOOST_FOREACH(const std::string& child, it->second)
+            // BOOST_FOREACH(const std::string& child, it->second)
+            for(const std::string& child : it->second)
             {
                 QTreeWidgetItem* childItem = new QTreeWidgetItem(rootItem);
                 childItem->setText(1, QString(child.c_str()));
-                m_treeItems.push_back(childItem);
+                // m_treeItems.push_back(childItem);
+                m_treeItems.push_back(std::unique_ptr<QTreeWidgetItem>(childItem));
+
             }
-            m_treeItems.push_back(rootItem);
+            //m_treeItems.push_back(rootItem);
+            m_treeItems.push_back(std::unique_ptr<QTreeWidgetItem>(rootItem));
         }
         m_ui->capabilitiesTree->resizeColumnToContents(0);
         m_ui->capabilitiesTree->resizeColumnToContents(1);
 
         // score listing
         i = 0;
-        const std::vector<std::pair<boost::int32_t, std::string> >& reasons(m_parser->getReasons());
+        // const std::vector<std::pair<boost::int32_t, std::string> >& reasons(m_parser->getReasons());
+        const std::vector<std::pair<std::int32_t, std::string> >& reasons(m_parser->getReasons());
         m_ui->scoringTable->setRowCount(reasons.size());
         m_ui->scoringTable->setSortingEnabled(false);
-        for (std::vector<std::pair<boost::int32_t, std::string> >::const_iterator reason = reasons.begin();
+        // for (std::vector<std::pair<boost::int32_t, std::string> >::const_iterator reason = reasons.begin();
+        for (std::vector<std::pair<std::int32_t, std::string> >::const_iterator reason = reasons.begin();
              reason != reasons.end(); ++reason)
         {
             tableItem = new IntWidgetItem(reason->first);
             m_ui->scoringTable->setItem(i, 0, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             tableItem = new QTableWidgetItem(QString(reason->second.c_str()));
             m_ui->scoringTable->setItem(i, 1, tableItem);
-            m_tableItems.push_back(tableItem);
+            //m_tableItems.push_back(tableItem);
+            m_tableItems.push_back(std::unique_ptr<QTableWidgetItem>(tableItem));
             ++i;
         }
         m_ui->scoringTable->setSortingEnabled(true);
@@ -367,7 +431,8 @@ void MainWindow::overviewToClipboard()
     QItemSelectionModel* selected = m_ui->overviewTable->selectionModel();
     if (selected->hasSelection())
     {
-        BOOST_FOREACH(const QModelIndex& index, selected->selectedRows())
+        // BOOST_FOREACH(const QModelIndex& index, selected->selectedRows())
+        for(const QModelIndex& index : selected->selectedRows())
         {
             QApplication::clipboard()->setText(m_ui->overviewTable->item(index.row(), 0)->text());
         }
@@ -379,7 +444,8 @@ void MainWindow::sectionSelected(QTableWidgetItem* p_first, QTableWidgetItem* p_
     Q_UNUSED(p_first);
     Q_UNUSED(p_second);
     QTableWidgetItem* selected = m_ui->sectionsTable->item(p_first->row(), 5);
-    std::string details(m_parser->getSegments().printSegment(boost::lexical_cast<boost::uint64_t>(selected->text().toStdString())));
+    //std::string details(m_parser->getSegments().printSegment(boost::lexical_cast<boost::uint64_t>(selected->text().toStdString())));
+    std::string details(m_parser->getSegments().printSegment(std::stoull(selected->text().toStdString())));
     m_ui->sectionInfo->setPlainText(QString(details.c_str()));
 }
 
@@ -388,7 +454,8 @@ void MainWindow::programSelected(QTableWidgetItem* p_first, QTableWidgetItem* p_
     Q_UNUSED(p_first);
     Q_UNUSED(p_second);
     QTableWidgetItem* selected = m_ui->programsTable->item(p_first->row(), 1);
-    std::string details(m_parser->getSegments().printSegment(boost::lexical_cast<boost::uint64_t>(selected->text().toStdString())));
+    //std::string details(m_parser->getSegments().printSegment(boost::lexical_cast<boost::uint64_t>(selected->text().toStdString())));
+    std::string details(m_parser->getSegments().printSegment(std::stoull(selected->text().toStdString())));
     m_ui->programsInfo->setPlainText(QString(details.c_str()));
 }
 
@@ -424,7 +491,10 @@ void MainWindow::on_aboutButton_clicked()
         std::string dir;
 #ifdef APPLE
         dir.assign(QApplication::applicationDirPath().toStdString());
-        boost::replace_last(dir, "MacOS", "Resources/icon_72529.png");
+        // boost::replace_last(dir, "MacOS", "Resources/icon_72529.png");
+        dir.replace(dir.rfind("MacOS"), 5, "Resources/icon_72529.png");
+
+
 #elif WINDOWS
         dir.assign("./icon_72529.png");
 #else

--- a/src/ui/mainwindow.h
+++ b/src/ui/mainwindow.h
@@ -1,3 +1,4 @@
+//boost free
 void on_aboutButton_clicked();
 #ifdef QT_GUI
 #ifndef MAINWINDOW_H
@@ -6,10 +7,10 @@ void on_aboutButton_clicked();
 #include <QMainWindow>
 
 
-#include <boost/scoped_ptr.hpp>
+//#include <boost/scoped_ptr.hpp>
 #include <memory>
 
-#include <boost/ptr_container/ptr_vector.hpp>
+//#include <boost/ptr_container/ptr_vector.hpp>
 #include <vector>
 
 namespace Ui {
@@ -38,24 +39,43 @@ private slots:
     void sectionSelected(QTableWidgetItem*, QTableWidgetItem*);
     void programSelected(QTableWidgetItem*, QTableWidgetItem*);
 
+// private:
+//     //! The main window that is created by mainwindow.ui
+//     Ui::MainWindow* m_ui;
+
+//     //! The dialog window
+//     boost::scoped_ptr<QDialog> m_dialog;
+
+//     //! All the allocated Table values
+//     boost::ptr_vector<QTableWidgetItem> m_tableItems;
+
+//     //! All the allocated Tree values
+//     boost::ptr_vector<QTreeWidgetItem> m_treeItems;
+
+//     //! The reusable copy action
+//     boost::scoped_ptr<QAction> m_copyAction;
+
+//     //! The reusable ELF parser
+//     boost::scoped_ptr<ELFParser> m_parser;
+// };
 private:
     //! The main window that is created by mainwindow.ui
     Ui::MainWindow* m_ui;
 
     //! The dialog window
-    boost::scoped_ptr<QDialog> m_dialog;
+    std::unique_ptr<QDialog> m_dialog;
 
     //! All the allocated Table values
-    boost::ptr_vector<QTableWidgetItem> m_tableItems;
+    std::vector<std::unique_ptr<QTableWidgetItem>> m_tableItems;
 
     //! All the allocated Tree values
-    boost::ptr_vector<QTreeWidgetItem> m_treeItems;
+    std::vector<std::unique_ptr<QTreeWidgetItem>> m_treeItems;
 
     //! The reusable copy action
-    boost::scoped_ptr<QAction> m_copyAction;
+    std::unique_ptr<QAction> m_copyAction;
 
     //! The reusable ELF parser
-    boost::scoped_ptr<ELFParser> m_parser;
+    std::unique_ptr<ELFParser> m_parser;
 };
 
 #endif // MAINWINDOW_H


### PR DESCRIPTION
Last of the boost code removed. All that remains is to update the CMakeLists and remove the boost packages from it.

Boost removed from:
src/abstract_dynamic.hpp
src/abstract_elfheader.hpp
src/abstract_programheader.hpp
src/abstract_sectionheader.hpp
src/abstract_segments.cpp
src/datastructures/search_node.cpp
src/datastructures/search_node.hpp
src/datastructures/search_tree.cpp
src/datastructures/search_tree.hpp
src/datastructures/search_value.hpp
src/dynamicsection.hpp
src/segment_types/comment_segment.cpp
src/segment_types/comment_segment.hpp
src/segment_types/debuglink_segment.cpp
src/segment_types/debuglink_segment.hpp
src/segment_types/interp_segment.cpp
src/segment_types/interp_segment.hpp
src/segment_types/note_segment.cpp
src/segment_types/note_segment.hpp
src/segment_types/readonly_segment.cpp
src/segment_types/readonly_segment.hpp
src/segment_types/segment_type.cpp
src/segment_types/segment_type.hpp
src/segment_types/strtable_segment.cpp
src/segment_types/strtable_segment.hpp
src/structures/capabilities.hpp
src/structures/dynamicstruct.hpp
src/structures/elfheader.hpp
src/structures/noteformat.hpp
src/structures/programheader.hpp
src/structures/relocation.hpp
src/structures/sectionheader.hpp
src/structures/symtable_entry.hpp
src/symbols.cpp
src/tests/ls_tests.cpp
src/tests/tiny_tests.cpp
src/ui/inttablewidget.cpp
src/ui/inttablewidget.hpp
src/ui/mainwindow.cpp
src/ui/mainwindow.h